### PR TITLE
Resolved issues with counts from InSpec 4.18.x data - fixed `inspecjs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall-lite",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8827,9 +8827,9 @@
       }
     },
     "inspecjs": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/inspecjs/-/inspecjs-0.8.1.tgz",
-      "integrity": "sha512-JM6z6roEdmLID7OyeQBnWhvP33ThK44ceSzqZfzwgM7madNyPvI3+2vh0EPrW9DXEYNkBVsFBXbwzvtDZJmfLA=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/inspecjs/-/inspecjs-0.8.2.tgz",
+      "integrity": "sha512-h+2d43TDJ634WuJxAWXLWZ4f5fTu3ChvePEIUjsrZ03UC49us4TiVzPBsB+Hf9C9LeQQGeTt7EFNGa9nEDHAng=="
     },
     "internal-ip": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8827,9 +8827,9 @@
       }
     },
     "inspecjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/inspecjs/-/inspecjs-0.8.2.tgz",
-      "integrity": "sha512-h+2d43TDJ634WuJxAWXLWZ4f5fTu3ChvePEIUjsrZ03UC49us4TiVzPBsB+Hf9C9LeQQGeTt7EFNGa9nEDHAng=="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/inspecjs/-/inspecjs-0.8.3.tgz",
+      "integrity": "sha512-8f5BtVRgky4X2FuXhKLiW7Sat8b+WvA87rYCVaO5lQGIm2LeEFPFDggcBWpN3WAZi4LA2eEFmsJiz4U8WQpjVA=="
     },
     "internal-ip": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-inline-source-plugin": "0.0.10",
     "html-webpack-plugin": "^3.2.0",
-    "inspecjs": "0.8.2",
+    "inspecjs": "0.8.3",
     "lru-cache": "^5.1.1",
     "material-components-web": "^3.2.0",
     "prismjs": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall-lite",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Heimdall Lite 2.0 is a JavaScript based security results viewer and review tool supporting multiple security results formats, such as: InSpec, SonarQube, OWASP-Zap and Fortify which you can load locally, from S3 and other data sources.",
   "private": true,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-inline-source-plugin": "0.0.10",
     "html-webpack-plugin": "^3.2.0",
-    "inspecjs": "0.8.1",
+    "inspecjs": "0.8.2",
     "lru-cache": "^5.1.1",
     "material-components-web": "^3.2.0",
     "prismjs": "^1.17.1",


### PR DESCRIPTION
- Resolved issues with counting for results from InSpec 4.18.x and above ( Fixed #183 )
- Bumped inspecjs version to 0.8.3 which correctly supports InSpec 4.18.x (#184)
- Updated npm packages and package.lock
- Added video walkthrough on the README

Fixes #183 
Fixes #184 

```
Failed to compile with 23 errors                                                                                                    11:00:02 AM

 error  in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue

ERROR in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue
204:22 Property 'raw_nist_tags' does not exist on type 'HDFControl'.
    202 |       {
    203 |         name: "Nist",
  > 204 |         value: c.hdf.raw_nist_tags.join(", ")
        |                      ^
    205 |       },
    206 |       {
    207 |         name: "Check Text",

 error  in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue

ERROR in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue
208:43 Property 'descriptions' does not exist on type 'HDFControl'.
    206 |       {
    207 |         name: "Check Text",
  > 208 |         value: c.data.tags.check || c.hdf.descriptions.check
        |                                           ^
    209 |       },
    210 |       {
    211 |         name: "Fix Text",

 error  in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue

ERROR in /Users/lmalinowski/git/hl/src/components/cards/controltable/ControlRowDetails.vue
212:41 Property 'descriptions' does not exist on type 'HDFControl'.
    210 |       {
    211 |         name: "Fix Text",
  > 212 |         value: c.data.tags.fix || c.hdf.descriptions.fix
        |                                         ^
    213 |       }
    214 |     ];
    215 |   }

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue
59:32 Property 'parsed_nist_tags' does not exist on type 'HDFControl'.
    57 | 
    58 |     // Figure out the nist tags to make a family
  > 59 |     let root_control = control.parsed_nist_tags[0];
       |                                ^
    60 |     let family = root_control.family || "UM";
    61 |     let pad = (x: string) => ("00" + x).slice(-2); // Pads a string to two digits
    62 |     let nist_control_number = pad(root_control.sub_specifiers[1] || "01");

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue
106:56 Property 'descriptions' does not exist on type 'HDFControl'.
    104 |       row.push(""); //row.push("InSpec"); // Assessment/Audit Company
    105 |       row.push("Test"); // Test Method
  > 106 |       row.push(fix(control.wraps.tags.check || control.descriptions.check)); // Test Objective
        |                                                        ^
    107 |       let test_result = `${control.status}: ${control.message.replace(
    108 |         "\n",
    109 |         "; "

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportCaat.vue
117:54 Property 'descriptions' does not exist on type 'HDFControl'.
    115 |         row.push("Other Than Satisfied");
    116 |       }
  > 117 |       row.push(fix(control.wraps.tags.fix || control.descriptions.fix)); // Recommended Corrective Action(s)
        |                                                      ^
    118 |       row.push(""); // Effect on Business
    119 |       row.push(""); // Likelihood
    120 |       row.push(fix(control.severity)); // Impact

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue
27:10 Module '"../../../../../../../Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist"' has no exported member 'NistControl'.
    25 |   LinkAction
    26 | } from "@/components/global/sidebaritems/SidebarLink.vue";
  > 27 | import { NistControl } from "inspecjs/dist/nist";
       |          ^
    28 | import { FileID, ExecutionFile } from "../../store/report_intake";
    29 | import InspecDataModule from "../../store/data_store";
    30 | 

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue
100:29 Property 'parsed_nist_tags' does not exist on type 'HDFControl'.
     98 |     let nist_controls: NistControl[] = [];
     99 |     controls.forEach(c => {
  > 100 |       let tags = c.root.hdf.parsed_nist_tags;
        |                             ^
    101 |       tags.forEach(t => {
    102 |         if (
    103 |           !nist_controls.some(

 error  in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue

ERROR in /Users/lmalinowski/git/hl/src/components/global/ExportNist.vue
101:20 Parameter 't' implicitly has an 'any' type.
     99 |     controls.forEach(c => {
    100 |       let tags = c.root.hdf.parsed_nist_tags;
  > 101 |       tags.forEach(t => {
        |                    ^
    102 |         if (
    103 |           !nist_controls.some(
    104 |             other_tag => this.format_tag(other_tag) === this.format_tag(t)

 error  in /Users/lmalinowski/git/hl/src/store/data_filters.ts

ERROR in /Users/lmalinowski/git/hl/src/store/data_filters.ts
204:32 Property 'NistControl' does not exist on type 'typeof import("/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist")'.
    202 | 
    203 |         // Construct a nist control to represent the filter
  > 204 |         let control = new nist.NistControl(filter.tree_filters);
        |                                ^
    205 | 
    206 |         controls = controls.filter(c => {
    207 |           // Get an hdf version so we have the fixed nist tags

 error  in /Users/lmalinowski/git/hl/src/store/data_filters.ts

ERROR in /Users/lmalinowski/git/hl/src/store/data_filters.ts
208:29 Property 'parsed_nist_tags' does not exist on type 'HDFControl'.
    206 |         controls = controls.filter(c => {
    207 |           // Get an hdf version so we have the fixed nist tags
  > 208 |           return c.root.hdf.parsed_nist_tags.some(t => control.contains(t));
        |                             ^
    209 |         });
    210 |       }
    211 | 

 error  in /Users/lmalinowski/git/hl/src/store/data_filters.ts

ERROR in /Users/lmalinowski/git/hl/src/store/data_filters.ts
208:51 Parameter 't' implicitly has an 'any' type.
    206 |         controls = controls.filter(c => {
    207 |           // Get an hdf version so we have the fixed nist tags
  > 208 |           return c.root.hdf.parsed_nist_tags.some(t => control.contains(t));
        |                                                   ^
    209 |         });
    210 |       }
    211 | 

 error  in /Users/lmalinowski/git/hl/src/utilities/delta_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/delta_util.ts
177:27 Property 'raw_nist_tags' does not exist on type 'HDFControl'.
    175 |       new ControlChange(
    176 |         "NIST Tags",
  > 177 |         this.old.root.hdf.raw_nist_tags.join(", "),
        |                           ^
    178 |         this.new.root.hdf.raw_nist_tags.join(", ")
    179 |       )
    180 |     );

 error  in /Users/lmalinowski/git/hl/src/utilities/delta_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/delta_util.ts
178:27 Property 'raw_nist_tags' does not exist on type 'HDFControl'.
    176 |         "NIST Tags",
    177 |         this.old.root.hdf.raw_nist_tags.join(", "),
  > 178 |         this.new.root.hdf.raw_nist_tags.join(", ")
        |                           ^
    179 |       )
    180 |     );
    181 | 

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
23:22 Namespace '"/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist"' has no exported member 'NistControl'.
    21 |   color?: Chroma.Color;
    22 |   parent: TreemapNodeParent | null; // The parent of this node.
  > 23 |   nist_control: nist.NistControl; // The nist control which this node is associated with. Not necessarily unique (e.g. leaves)
       |                      ^
    24 | }
    25 | export interface TreemapNodeParent extends AbsTreemapNode {
    26 |   children: TreemapNode[]; // Maps the next sub-specifier to children

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
58:24 Property 'parsed_nist_tags' does not exist on type 'HDFControl'.
    56 |     let color = Chroma.hex(colors.colorForStatus(cc.root.hdf.status));
    57 |     // Now make leaves for each nist control
  > 58 |     return cc.root.hdf.parsed_nist_tags.map(nc => {
       |                        ^
    59 |       let leaf: TreemapNodeLeaf = {
    60 |         title: cc.data.id,
    61 |         subtitle: cc.data.title || undefined,

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
58:45 Parameter 'nc' implicitly has an 'any' type.
    56 |     let color = Chroma.hex(colors.colorForStatus(cc.root.hdf.status));
    57 |     // Now make leaves for each nist control
  > 58 |     return cc.root.hdf.parsed_nist_tags.map(nc => {
       |                                             ^
    59 |       let leaf: TreemapNodeLeaf = {
    60 |         title: cc.data.id,
    61 |         subtitle: cc.data.title || undefined,

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
80:23 Namespace '"/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist"' has no exported member 'NistHierarchyNode'.
    78 | function recursive_nist_map(
    79 |   parent: TreemapNodeParent | null,
  > 80 |   node: Readonly<nist.NistHierarchyNode>,
       |                       ^
    81 |   control_lookup: { [key: string]: TreemapNodeParent },
    82 |   max_depth: number
    83 | ): TreemapNodeParent {

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
98:27 Parameter 'child' implicitly has an 'any' type.
     96 |   // Fill our children
     97 |   if (node.control.sub_specifiers.length < max_depth) {
  >  98 |     node.children.forEach(child => {
        |                           ^
     99 |       // Get the last subspec.
    100 |       let final_subspec =
    101 |         child.control.sub_specifiers[child.control.sub_specifiers.length - 1];

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
136:33 Namespace '"/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist"' has no exported member 'NistControl'.
    134 | 
    135 | /** Generates a lookup key for the given control */
  > 136 | function lookup_key_for(x: nist.NistControl, max_depth: number): string {
        |                                 ^
    137 |   if (max_depth) {
    138 |     return x.sub_specifiers.slice(0, max_depth).join("-");
    139 |   } else {

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
182:28 Property 'NistControl' does not exist on type 'typeof import("/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist")'.
    180 |     children: root_children,
    181 |     parent: null,
  > 182 |     nist_control: new nist.NistControl([], "NIST-853")
        |                            ^
    183 |   };
    184 | 
    185 |   // Fill out children, recursively

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
186:8 Property 'FULL_NIST_HIERARCHY' does not exist on type 'typeof import("/Users/lmalinowski/git/hl/node_modules/inspecjs/dist/nist")'.
    184 | 
    185 |   // Fill out children, recursively
  > 186 |   nist.FULL_NIST_HIERARCHY.forEach(n => {
        |        ^
    187 |     let child = recursive_nist_map(root, n, lookup, MAX_DEPTH);
    188 |     let tag = child.nist_control.sub_specifiers[0];
    189 |     root_children.push(child);

 error  in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts

ERROR in /Users/lmalinowski/git/hl/src/utilities/treemap_util.ts
186:36 Parameter 'n' implicitly has an 'any' type.
    184 | 
    185 |   // Fill out children, recursively
  > 186 |   nist.FULL_NIST_HIERARCHY.forEach(n => {
        |                                    ^
    187 |     let child = recursive_nist_map(root, n, lookup, MAX_DEPTH);
    188 |     let tag = child.nist_control.sub_specifiers[0];
    189 |     root_children.push(child);

 ERROR  Build failed with errors.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! heimdall-lite@2.0.5 build: `vue-cli-service build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the heimdall-lite@2.0.5 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/lmalinowski/.npm/_logs/2019-11-15T16_00_02_858Z-debug.log
```


Signed-off-by: Luke Malinowski <lmalinowski@mitre.org>