### PR TITLE
Unify prettierrc with the one in heimdall2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": false,
+}


### PR DESCRIPTION
This provides us with a consistent style and spacing across the two projects in preparation to merge them into 1 repo.

I have been working with the `heimdall-lite` folder nested inside of `heimdall2` and the linter walks up directories until it finds a `.prettierrc`file. This is why I put up #276 without realizing this was only happening on my machine.