### PR TITLE
Use GitHub Actions integrated linter instead of running npm run lint

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,11 +17,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: npm installbuild, and test
         run: npm install
+      - name: Run linters
+        uses: samuelmeuli/lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          prettier: true
+          eslint: true
       - name: npm build
         run: npm run build
       - name: npm test
         run: npm run test:unit
-      - name: npm lint 
-        run: npm run lint
-        env:
-          CI: true


### PR DESCRIPTION
running the linter directly does not ever return an error code of 0 meaning it was always fixing files in CI and then promptly throwing them away since they were never committed. By using a marketplace action to do this it should fix the problem.