### PR TITLE
Set the maximum number of allowed warnings for eslint

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,13 +15,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: npm installbuild, and test
+      - name: npm install
         run: npm install
+      - name: npm lint
+        run: npm run lint:ci
+        env:
+          CI: true
       - name: npm build
         run: npm run build
       - name: npm test
         run: npm run test:unit
-      - name: npm lint 
-        run: npm run lint
-        env:
-          CI: true

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "vue-cli-service build",
     "prepack": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint:ci": "vue-cli-service lint --no-fix  --maxWarnings 0",
     "test:unit": "jest"
   },
   "dependencies": {

--- a/src/components/global/UserMenu.vue
+++ b/src/components/global/UserMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <v-menu open-on-hover offset-y v-if="is_server_mode">
-    <template v-slot:activator="{ on, attrs }">
+    <template v-slot:activator="{on, attrs}">
       <v-btn class="mx-2" v-on="on">
         <v-icon>
           mdi-account
@@ -19,8 +19,8 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import Component from "vue-class-component";
+import Vue from 'vue';
+import Component from 'vue-class-component';
 
 // We declare the props separately to make props types inferable.
 const UserMenuProps = Vue.extend({

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -138,13 +138,13 @@ import UploadNexus from '@/components/global/UploadNexus.vue';
 import InspecIntakeModule, {
   FileID,
   next_free_file_ID
-} from "@/store/report_intake";
-import { plainToClass } from "class-transformer";
-import { getModule } from "vuex-module-decorators";
-import InspecDataModule from "../store/data_store";
-import ServerModule from "@/store/server";
-import { UserProfile, Evaluation, Usergroup } from "@/types/models.ts";
-import UserMenu from "@/components/global/UserMenu.vue";
+} from '@/store/report_intake';
+import {plainToClass} from 'class-transformer';
+import {getModule} from 'vuex-module-decorators';
+import InspecDataModule from '../store/data_store';
+import ServerModule from '@/store/server';
+import {UserProfile, Evaluation, Usergroup} from '@/types/models.ts';
+import UserMenu from '@/components/global/UserMenu.vue';
 
 export interface RetrieveHash {
   unique_id: number;
@@ -362,7 +362,7 @@ export default class Profile extends ProfileProps {
 
   profile_page() {
     this.dialog = false;
-    this.$router.push("/profile");
+    this.$router.push('/profile');
   }
 
   log_out() {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -138,31 +138,31 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import Component from "vue-class-component";
-import BaseView from "@/views/BaseView.vue";
-import UploadNexus from "@/components/global/UploadNexus.vue";
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import BaseView from '@/views/BaseView.vue';
+import UploadNexus from '@/components/global/UploadNexus.vue';
 
-import StatusCardRow from "@/components/cards/StatusCardRow.vue";
-import ControlTable from "@/components/cards/controltable/ControlTable.vue";
-import Treemap from "@/components/cards/treemap/Treemap.vue";
-import StatusChart from "@/components/cards/StatusChart.vue";
-import SeverityChart from "@/components/cards/SeverityChart.vue";
-import ComplianceChart from "@/components/cards/ComplianceChart.vue";
-import ProfileData from "@/components/cards/ProfileData.vue";
-import ExportCaat from "@/components/global/ExportCaat.vue";
-import ExportNist from "@/components/global/ExportNist.vue";
-import ExportJson from "@/components/global/ExportJson.vue";
-import EvaluationInfo from "@/components/cards/EvaluationInfo.vue";
+import StatusCardRow from '@/components/cards/StatusCardRow.vue';
+import ControlTable from '@/components/cards/controltable/ControlTable.vue';
+import Treemap from '@/components/cards/treemap/Treemap.vue';
+import StatusChart from '@/components/cards/StatusChart.vue';
+import SeverityChart from '@/components/cards/SeverityChart.vue';
+import ComplianceChart from '@/components/cards/ComplianceChart.vue';
+import ProfileData from '@/components/cards/ProfileData.vue';
+import ExportCaat from '@/components/global/ExportCaat.vue';
+import ExportNist from '@/components/global/ExportNist.vue';
+import ExportJson from '@/components/global/ExportJson.vue';
+import EvaluationInfo from '@/components/cards/EvaluationInfo.vue';
 
-import FilteredDataModule, { Filter, TreeMapState } from "@/store/data_filters";
-import { ControlStatus, Severity } from "inspecjs";
-import InspecIntakeModule, { FileID } from "@/store/report_intake";
-import { getModule } from "vuex-module-decorators";
-import InspecDataModule from "../store/data_store";
-import { need_redirect_file } from "@/utilities/helper_util";
-import ServerModule from "@/store/server";
-import UserMenu from "@/components/global/UserMenu.vue";
+import FilteredDataModule, {Filter, TreeMapState} from '@/store/data_filters';
+import {ControlStatus, Severity} from 'inspecjs';
+import InspecIntakeModule, {FileID} from '@/store/report_intake';
+import {getModule} from 'vuex-module-decorators';
+import InspecDataModule from '../store/data_store';
+import {need_redirect_file} from '@/utilities/helper_util';
+import ServerModule from '@/store/server';
+import UserMenu from '@/components/global/UserMenu.vue';
 
 // We declare the props separately
 // to make props types inferrable.
@@ -305,7 +305,7 @@ export default class Results extends ResultsProps {
 
   profile_page() {
     this.dialog = false;
-    this.$router.push("/profile");
+    this.$router.push('/profile');
   }
 
   log_out() {

--- a/src/views/Usergroup.vue
+++ b/src/views/Usergroup.vue
@@ -120,13 +120,13 @@ import UploadNexus from '@/components/global/UploadNexus.vue';
 import InspecIntakeModule, {
   FileID,
   next_free_file_ID
-} from "@/store/report_intake";
-import { plainToClass } from "class-transformer";
-import { getModule } from "vuex-module-decorators";
-import InspecDataModule from "../store/data_store";
-import ServerModule from "@/store/server";
-import { UserProfile, Evaluation, Usergroup } from "@/types/models.ts";
-import UserMenu from "@/components/global/UserMenu.vue";
+} from '@/store/report_intake';
+import {plainToClass} from 'class-transformer';
+import {getModule} from 'vuex-module-decorators';
+import InspecDataModule from '../store/data_store';
+import ServerModule from '@/store/server';
+import {UserProfile, Evaluation, Usergroup} from '@/types/models.ts';
+import UserMenu from '@/components/global/UserMenu.vue';
 
 export interface RetrieveHash {
   unique_id: number;
@@ -364,7 +364,7 @@ export default class UsergroupView extends UsergroupProps {
 
   profile_page() {
     this.dialog = false;
-    this.$router.push("/profile");
+    this.$router.push('/profile');
   }
 
   log_out() {


### PR DESCRIPTION
By default the vue-cli allows an unlimited number of warnings. In order to standardize, this sets the number of linter allowed warnings to 0, and then actually fails CI when the number of warnings drops below that threshold.

All of the warnings we currently have are easily fixed with the `npm run lint` autocorrector. I will push those up once I verify that this commit actually fails as it currently should.